### PR TITLE
test: import attributesのサポートをテスト

### DIFF
--- a/test/__fixtures__/import-with-attributes.ts
+++ b/test/__fixtures__/import-with-attributes.ts
@@ -1,0 +1,2 @@
+// @ts-nocheck
+import data from './data.json' with { type: 'json' };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -151,4 +151,19 @@ describe('scanImportDeclarations', () => {
 			},
 		]);
 	});
+
+	test('import with attributes', () => {
+		const actual = scanImportDeclarations(
+			'test/__fixtures__/import-with-attributes.ts',
+		);
+		expect(actual.map(({ details }) => ({ details }))).toStrictEqual([
+			{
+				details: {
+					type: 'default_import',
+					isTypeOnly: false,
+					importedBinding: 'data',
+				},
+			},
+		]);
+	});
 });


### PR DESCRIPTION
## 概要

ES2020のimport attributes構文に対するサポートをテストするため、新しいテストケースとフィクスチャを追加しました。

- `import data from './data.json' with { type: 'json' }` のような構文の検出をテスト
- `scanImportDeclarations`がimport attributesを含むimport文を正しく処理できることを確認

## 変更内容

- **テストフィクスチャ追加**: `test/__fixtures__/import-with-attributes.ts`
  - import attributes構文を使用したJSONインポートのサンプル
- **テストケース追加**: `test/index.test.ts`
  - import attributesを使用したdefault importの検出をテスト
  - 既存の機能に影響がないことを確認

## テスト計画

- [x] 新しいテストケース「import with attributes」が正常に実行される
- [x] 既存のテストケースがすべて通ることを確認
- [x] import attributesを含むファイルが正しく解析される
- [x] default importとして正しく検出される
- [x] typeOnlyがfalseとして検出される

## パフォーマンス影響

既存のパーサー機能に変更はなく、テストケースの追加のみのため、パフォーマンスへの影響はありません。